### PR TITLE
Upgrade commons-lang3 from 3.9 to 3.10

### DIFF
--- a/protelis/versions.properties
+++ b/protelis/versions.properties
@@ -5,8 +5,10 @@
 ## Please, don't put extra comments in that file yet, keeping them is not supported yet.
 
 plugin.com.github.spotbugs=4.0.4
+##             # available=4.0.5
 
 plugin.com.jfrog.bintray=1.8.4
+##           # available=1.8.5
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
@@ -32,10 +34,13 @@ version.commons-io..commons-io=2.6
 version.de.ruedigermoeller..fst=2.57
 
 version.io.github.classgraph..classgraph=4.8.65
+##                           # available=4.8.68
 
 version.it.unibo.alchemist..alchemist-interfaces=4.0.0
+##                                   # available=9.3.0
 
 version.it.unibo.alchemist..alchemist-loading=4.0.0
+##                                # available=9.3.0
 
 version.junit.junit=4.13
 
@@ -44,7 +49,7 @@ version.kotlin=1.3.50
 
 version.net.sf.trove4j..trove4j=3.0.3
 
-version.org.apache.commons..commons-lang3=3.9
+version.org.apache.commons..commons-lang3=3.10
 
 version.org.apache.commons..commons-math3=3.6.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.